### PR TITLE
Add /products/ route and demo view/template

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 from django.urls import path
-from pages.views import HomeView, AboutView, ContactsView, ProductView
+from pages.views import HomeView, AboutView, ContactsView, ProductView, ProductsListView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", HomeView.as_view(), name="home"),
     path("about/", AboutView.as_view(), name="about"),
     path("contacts/", ContactsView.as_view(), name="contacts"),
+    path("products/", ProductsListView.as_view(), name="products"),
     path("product/<slug:slug>/", ProductView.as_view(), name="product"),
 ]

--- a/demo_menu.json
+++ b/demo_menu.json
@@ -48,7 +48,7 @@
             "title": "Products",
             "order": 3,
             "named_url": null,
-            "url": "/product/x/"
+            "url": "/products/"
         }
     },
     {

--- a/menu/templates/menu/_node.html
+++ b/menu/templates/menu/_node.html
@@ -1,15 +1,17 @@
 <li class="{% if node.is_active %}active{% endif %}">
-    {% if node.named_url %}
-    <a href="{% url node.named_url %}">{{ node.title }}</a>
+    {% if node.href %}
+    <a href="{{ node.href }}">{{ node.title }}</a>
     {% else %}
-    <a href="{{ node.url }}">{{ node.title }}</a>
+    <span>{{ node.title }}</span>
     {% endif %}
 
-    {% if node.children and node.is_open %}
-    <ul>
+    {% if node.children %}
+    {% if node.is_open or node.is_active %}
+    <ul class="open">
         {% for child in node.children %}
-        {% include "menu/_node.html" with node=child %}
+        {% include "menu/_node.html" with node=child only %}
         {% endfor %}
     </ul>
+    {% endif %}
     {% endif %}
 </li>

--- a/menu/templatetags/menu_tags.py
+++ b/menu/templatetags/menu_tags.py
@@ -6,7 +6,6 @@ from ..models import MenuItem
 register = template.Library()
 
 def _resolve_item_url(item: dict) -> Optional[str]:
-    """Преобразуем named_url в реальный путь (reverse) либо берём явный url."""
     if item.get("named_url"):
         try:
             return reverse(item["named_url"])
@@ -15,13 +14,13 @@ def _resolve_item_url(item: dict) -> Optional[str]:
     return item.get("url")
 
 def _build_tree(items: List[dict]) -> dict:
-    """Собираем дерево в памяти: индексы по parent_id и id."""
     by_parent: Dict[Optional[int], List[dict]] = {}
     by_id: Dict[int, dict] = {}
     for it in items:
         it["children"] = []
         it["is_active"] = False
         it["is_open"] = False
+        it["href"] = None
         by_id[it["id"]] = it
         by_parent.setdefault(it["parent_id"], []).append(it)
 
@@ -36,7 +35,6 @@ def _norm(p: Optional[str]) -> Optional[str]:
     return p if p.endswith("/") else p + "/"
 
 def _find_active_id(items: List[dict], req_path: str) -> Optional[int]:
-    """Сопоставляем текущий путь с URL пунктов меню."""
     rp = _norm(req_path)
     for it in items:
         target = _norm(_resolve_item_url(it))
@@ -45,7 +43,6 @@ def _find_active_id(items: List[dict], req_path: str) -> Optional[int]:
     return None
 
 def _open_branch(by_id: dict, active_id: Optional[int]) -> None:
-    """Отмечаем активную ветку: все предки открыты, активный узел помечен."""
     cur = by_id.get(active_id) if active_id else None
     while cur:
         cur["is_open"] = True
@@ -65,6 +62,11 @@ def draw_menu(context, menu_name: str):
     )
 
     tree = _build_tree(items)
+
+    for it in items:
+        href = _resolve_item_url(it)
+        tree["by_id"][it["id"]]["href"] = href
+
     active_id = _find_active_id(items, request.path if request else "")
     _open_branch(tree["by_id"], active_id)
 

--- a/pages/templates/pages/products.html
+++ b/pages/templates/pages/products.html
@@ -3,7 +3,7 @@
 <html>
 
 <body>
-    <h1>Product page</h1>
+    <h1>Products page</h1>
     {% draw_menu 'main' %}
 </body>
 

--- a/pages/views.py
+++ b/pages/views.py
@@ -10,5 +10,8 @@ class AboutView(TemplateView):
 class ContactsView(TemplateView):
     template_name = "pages/contacts.html"
 
+class ProductsListView(TemplateView):
+    template_name = "pages/products.html"
+
 class ProductView(TemplateView):
-    template_name = "pages/product.html"
+    template_name = "pages/products.html"


### PR DESCRIPTION
Problem
- Пункт меню «Products» вёл на /products/, которого не было в URLconf → 404.

Solution
- Добавлен маршрут products/ + простая вьюха ProductsListView и шаблон pages/products.html.
- Родительский пункт меню «Products» теперь указывает на реальный маршрут (/products/ или named_url="products").

